### PR TITLE
Add support for delegating request methods via proxy method

### DIFF
--- a/lib/dav4rack/handler.rb
+++ b/lib/dav4rack/handler.rb
@@ -28,7 +28,9 @@ module DAV4Rack
           controller_class = @options[:controller_class] || Controller
           controller = controller_class.new(request, response, @options)
           controller.authenticate
-          res = controller.send(request.request_method.downcase)
+
+          method = request.request_method.downcase
+          res = controller.respond_to?(:process) ? controller.process(method) : controller.send(method)
         rescue HTTPStatus::Status => status
           res = status
         ensure

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -307,4 +307,23 @@ describe DAV4Rack::Handler do
       response.headers['location'].should =~ /http:\/\/localhost(:\d+)?\/webdav\/test/
     end
   end
+
+  describe "delegating webdav request methods to the controller" do
+
+    it 'calls #process if the controller respond to' do
+      my_controller = Class.new(DAV4Rack::Controller) do
+        def process(_action)
+        end
+      end
+      @controller = described_class.new(root: DOC_ROOT, controller_class: my_controller)
+
+      expect_any_instance_of(my_controller).to receive(:process).with('head')
+      request 'head', '/'
+    end
+
+    it 'calls send otherwhise' do
+      expect_any_instance_of(DAV4Rack::Controller).to receive(:send).with('head')
+      head '/'
+    end
+  end
 end


### PR DESCRIPTION
Hi,

we use this gem in a Rails application and have the need to add some behaviour before/after request methods are called. Currently the `Dav4Rack::Handler` delegates by just calling `#send` on the controller. Instead of overriding `def get, def post ...` I was looking for a more Rails-like solution.

With this PR the handler calls `#process` on the controller instance (if defined) just the same way it was calling `#send` before. This enables us to customise the behaviour of the controller easily.

In our example we add `#process`, `#process_action` to our `DAV4Rack::Controller` base controller and enable it to have before- and after_actions by including Rails `AbstractController::Callbacks` like any of our "normal" rails controllers do.

What do you think about this addition?
