### PR TITLE
Fix immutable string issue in response.body

### DIFF
--- a/lib/dav4rack/resources/file_resource.rb
+++ b/lib/dav4rack/resources/file_resource.rb
@@ -70,7 +70,7 @@ module DAV4Rack
     def get(request, response)
       return NotFound unless exist?
       if stat.directory?
-        response.body = ""
+        response.body = "".dup
         Rack::Directory.new(root).call(request.env)[2].each do |line|
           response.body << line
         end


### PR DESCRIPTION
Hi,

I've fixed an "can't modify frozen string" exception raised when accessing a webdav directory. Commit 057d13 added `frozen_string_literal: true` to `resources/file_resources.rb` causing this issue.


