### PR TITLE
content_lenght might be nil

### DIFF
--- a/lib/dav4rack/request.rb
+++ b/lib/dav4rack/request.rb
@@ -103,7 +103,7 @@ module DAV4Rack
 
     # parsed XML request body if any (Nokogiri XML doc)
     def document
-      @request_document ||= parse_request_body unless content_length == 0
+      @request_document ||= parse_request_body if content_length && content_length > 0
     end
 
     # builds a URL for path using this requests scheme, host, port and


### PR DESCRIPTION
When accessing WebDAV from Win7, the method `content_lenght` returns nil and a consequent method `parse_request_body` throws an exception and returns `BadRequest`. Therefore a WebDAV folder  can't be mounted. With this small fix it works fine.