### PR TITLE
remove dependency on webrick

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,5 @@
+* remove dependency on Webrick
+
 === v1.1.2
 * tests pass on Ruby 3
 * do not assume lock owner has a href child, preserve any owner value as-is

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,3 @@ gem 'puma'
 gem 'minitest'
 gem 'byebug', platforms: :mri
 gem 'ruby-prof'
-
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
-  # necessary for the file resource.
-  gem 'webrick'
-end

--- a/lib/dav4rack/resources/file_resource.rb
+++ b/lib/dav4rack/resources/file_resource.rb
@@ -2,15 +2,14 @@
 # frozen_string_literal: true
 
 require 'pstore'
-require 'webrick/httputils'
 require 'dav4rack/file_resource_lock'
 require 'dav4rack/security_utils'
+require 'rack/mime'
 
 module DAV4Rack
 
   class FileResource < Resource
 
-    include WEBrick::HTTPUtils
     include DAV4Rack::Utils
 
     # If this is a collection, return the child resources.
@@ -55,7 +54,7 @@ module DAV4Rack
       if stat.directory?
         "text/html"
       else
-        mime_type(file_path, DefaultMimeTypes)
+        ::Rack::Mime.mime_type(File.extname(file_path))
       end
     end
 


### PR DESCRIPTION
I don't think it's meaningful to depend on a webserver gem, just to load a few constants.

Rack has a very similar list which should be a good replacement.